### PR TITLE
Fixed lua nil error at item comparision tooltip

### DIFF
--- a/ConvertRatings.lua
+++ b/ConvertRatings.lua
@@ -298,7 +298,7 @@ local function getItemIdFromTooltip(self)
 		return;
 	end
 	
-	local itemLink = C_Item.GetItemLinkByGUID(guid)
+	local itemLink = C_Item.GetItemLinkByGUID(itemGuid)
 	
 	--Check to make sure an itemLink is actually returned
 	if(itemLink == nil) then

--- a/ConvertRatings.lua
+++ b/ConvertRatings.lua
@@ -2164,8 +2164,15 @@ local function getItemIdFromTooltip(self)
 	end	
 end
 
---Hooks to make the addon function
-TooltipDataProcessor.AddTooltipPostCall(Enum.TooltipDataType.Item, getItemIdFromTooltip)
+local function OnPlayerEnteringWorld(self, event)
+	--Hooks to make the addon function
+	TooltipDataProcessor.AddTooltipPostCall(Enum.TooltipDataType.Item, getItemIdFromTooltip)
+end
+
+--Create a frame to register the PLAYER_ENTERING_WORLD event to securly hook the tooltip's after everything is loaded 
+local frame = CreateFrame("Frame")
+frame:RegisterEvent("PLAYER_ENTERING_WORLD")
+frame:SetScript("OnEvent", OnPlayerEnteringWorld)
 
 --Old Hooks saved for reference
 --[[GameTooltip:HookScript("OnTooltipSetItem", getItemIdFromTooltip);

--- a/ConvertRatings.lua
+++ b/ConvertRatings.lua
@@ -293,12 +293,13 @@ local function getItemIdFromTooltip(self)
 	speedcap = speedfiftyperc + ((speedamt * 60) * 1.5)
 
 	local itemGuid = self:GetTooltipData()["guid"]
+	local itemLink = nil
 
 	if itemGuid == nil then
-		return;
+		itemLink = self:GetTooltipData()["hyperlink"]
+	else
+		itemLink = C_Item.GetItemLinkByGUID(itemGuid)
 	end
-	
-	local itemLink = C_Item.GetItemLinkByGUID(itemGuid)
 	
 	--Check to make sure an itemLink is actually returned
 	if(itemLink == nil) then

--- a/ConvertRatings.lua
+++ b/ConvertRatings.lua
@@ -292,8 +292,13 @@ local function getItemIdFromTooltip(self)
 	speedfiftyperc = speedfourtyperc + ((speedamt * 12) * 1.4)
 	speedcap = speedfiftyperc + ((speedamt * 60) * 1.5)
 
-   	--Get itemLink of mouseover 
-	local itemLink = C_Item.GetItemLinkByGUID(self:GetTooltipData()["guid"])	
+	local itemGuid = self:GetTooltipData()["guid"]
+
+	if itemGuid == nil then
+		return;
+	end
+	
+	local itemLink = C_Item.GetItemLinkByGUID(guid)
 	
 	--Check to make sure an itemLink is actually returned
 	if(itemLink == nil) then

--- a/ConvertRatings.lua
+++ b/ConvertRatings.lua
@@ -293,7 +293,7 @@ local function getItemIdFromTooltip(self)
 	speedcap = speedfiftyperc + ((speedamt * 60) * 1.5)
 
    	--Get itemLink of mouseover 
-	local name, itemLink = self:GetItem();		
+	local itemLink = C_Item.GetItemLinkByGUID(self:GetTooltipData()["guid"])	
 	
 	--Check to make sure an itemLink is actually returned
 	if(itemLink == nil) then


### PR DESCRIPTION
Fixed lua nil error at item comparision tooltip

Old:
local name, itemLink = self:GetItem()

New:
local itemLink = C_Item.GetItemLinkByGUID(self:GetTooltipData()["guid"])

Description:
The new tooltip for item comparision doesn't support the GetItem() function. Instead we extract the item guid from the raw tooltip data and query the belonging itemlink by using the  C_Item.GetItemLinkByGUID(guid) function.